### PR TITLE
Shimizu/issue2

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/TopActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/TopActivity.kt
@@ -9,6 +9,6 @@ import java.util.*
 class TopActivity : AppCompatActivity(R.layout.activity_top) {
 
     companion object {
-        lateinit var lastSearchDate: Date
+        var lastSearchDate: Date? = null
     }
 }


### PR DESCRIPTION
TopActivityのlastSearchDateのlateinit修飾子を削除しました。(varで十分なため)

issue2の他の問題については、pull requestを送る前にmainにマージしてしまったため、以下に実装した内容を簡単に記述します。

・非null 表明演算子について
OneFragmentni複数あったcontext!!などを、 !! を使わないように変更しました。

・強制ダウンキャストについて
型チェックを行い、明示的にキャストするようにした

・想定外のnullの握り潰し
nullチェックを行うべき箇所を修正しました。